### PR TITLE
Use ENV['ACCELA_ACCESS_TOKEN'] if present.

### DIFF
--- a/lib/accela/configuration.rb
+++ b/lib/accela/configuration.rb
@@ -22,9 +22,14 @@ module Accela
 
     attr_reader_safe :app_id, :app_secret, :agency, :environment
 
+    TokenFromEnv = Struct.new(:access_token)
     def self.token
-      raise InvalidTokenError.new("You do not have a token.") unless @token
-      @token
+      if access_token = ENV['ACCELA_ACCESS_TOKEN']
+        TokenFromEnv.new(access_token)
+      else
+        raise InvalidTokenError.new("You do not have a token.") unless @token
+        @token
+      end
     end
 
     def self.base_uri


### PR DESCRIPTION
The access token itself is not a full-token (with expiry date, etc), so
returns a sparse token struct with just the access_token method.

This should make it more obvious if questions arise like 'why doesn't the
token respond to #scope'.

The access token in ENV will always take precedence, so it should be
changed before it expires.  To revert to the standard Token object, just
unset the environment variable ACCELA_ACCESS_TOKEN.
